### PR TITLE
Done: Link Preview in iOS 13

### DIFF
--- a/SHRichTextEditorTools.xcodeproj/project.pbxproj
+++ b/SHRichTextEditorTools.xcodeproj/project.pbxproj
@@ -40,7 +40,7 @@
 		78D616DB216B73D500440E71 /* LinkInputAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78D616DA216B73D500440E71 /* LinkInputAlert.swift */; };
 		A866BE4B24A9D063009E4012 /* UITextView+LinkPresentationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A866BE4A24A9D062009E4012 /* UITextView+LinkPresentationHelper.swift */; };
 		A866BE4F24A9EC78009E4012 /* String+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A866BE4E24A9EC78009E4012 /* String+Helper.swift */; };
-		A866BE5124AA5790009E4012 /* MetadataStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A866BE5024AA5790009E4012 /* MetadataStorage.swift */; };
+		A8CD9C3124B8E90C0037EDE7 /* UserDefaults+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CD9C3024B8E90C0037EDE7 /* UserDefaults+Helper.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -100,7 +100,7 @@
 		78D616DA216B73D500440E71 /* LinkInputAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkInputAlert.swift; sourceTree = "<group>"; };
 		A866BE4A24A9D062009E4012 /* UITextView+LinkPresentationHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextView+LinkPresentationHelper.swift"; sourceTree = "<group>"; };
 		A866BE4E24A9EC78009E4012 /* String+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Helper.swift"; sourceTree = "<group>"; };
-		A866BE5024AA5790009E4012 /* MetadataStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataStorage.swift; sourceTree = "<group>"; };
+		A8CD9C3024B8E90C0037EDE7 /* UserDefaults+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Helper.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -150,6 +150,7 @@
 				788C6547215CFDC700AF46A6 /* NSAttributedString+Helper.swift */,
 				A866BE4A24A9D062009E4012 /* UITextView+LinkPresentationHelper.swift */,
 				A866BE4E24A9EC78009E4012 /* String+Helper.swift */,
+				A8CD9C3024B8E90C0037EDE7 /* UserDefaults+Helper.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -174,7 +175,6 @@
 				78D616D9216B6FDA00440E71 /* ImageInputHandler */,
 				788C655D215CFE0B00AF46A6 /* ImagePickerManager.swift */,
 				78D616DA216B73D500440E71 /* LinkInputAlert.swift */,
-				A866BE5024AA5790009E4012 /* MetadataStorage.swift */,
 			);
 			path = SHRichTextEditor;
 			sourceTree = "<group>";
@@ -433,10 +433,10 @@
 				788C6564215CFE0B00AF46A6 /* ImagePickerManager.swift in Sources */,
 				788C655B215CFDC700AF46A6 /* TextViewDelegate.swift in Sources */,
 				78B830361E5B0A32005B9057 /* AppDelegate.swift in Sources */,
+				A8CD9C3124B8E90C0037EDE7 /* UserDefaults+Helper.swift in Sources */,
 				78D616DB216B73D500440E71 /* LinkInputAlert.swift in Sources */,
 				78D616D8216B6F6E00440E71 /* TextViewImageInputHandler.swift in Sources */,
 				788C6565215CFE0B00AF46A6 /* SHRichTextEditor.swift in Sources */,
-				A866BE5124AA5790009E4012 /* MetadataStorage.swift in Sources */,
 				788C6559215CFDC700AF46A6 /* ToolBarButtonExtensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SHRichTextEditorTools.xcodeproj/project.pbxproj
+++ b/SHRichTextEditorTools.xcodeproj/project.pbxproj
@@ -38,6 +38,9 @@
 		78B830561E5B0A32005B9057 /* SHRichTextEditorToolsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78B830551E5B0A32005B9057 /* SHRichTextEditorToolsUITests.swift */; };
 		78D616D8216B6F6E00440E71 /* TextViewImageInputHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78D616D7216B6F6E00440E71 /* TextViewImageInputHandler.swift */; };
 		78D616DB216B73D500440E71 /* LinkInputAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78D616DA216B73D500440E71 /* LinkInputAlert.swift */; };
+		A866BE4B24A9D063009E4012 /* UITextView+LinkPresentationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A866BE4A24A9D062009E4012 /* UITextView+LinkPresentationHelper.swift */; };
+		A866BE4F24A9EC78009E4012 /* String+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A866BE4E24A9EC78009E4012 /* String+Helper.swift */; };
+		A866BE5124AA5790009E4012 /* MetadataStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A866BE5024AA5790009E4012 /* MetadataStorage.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -95,6 +98,9 @@
 		78B830571E5B0A32005B9057 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		78D616D7216B6F6E00440E71 /* TextViewImageInputHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewImageInputHandler.swift; sourceTree = "<group>"; };
 		78D616DA216B73D500440E71 /* LinkInputAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkInputAlert.swift; sourceTree = "<group>"; };
+		A866BE4A24A9D062009E4012 /* UITextView+LinkPresentationHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextView+LinkPresentationHelper.swift"; sourceTree = "<group>"; };
+		A866BE4E24A9EC78009E4012 /* String+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Helper.swift"; sourceTree = "<group>"; };
+		A866BE5024AA5790009E4012 /* MetadataStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataStorage.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -142,6 +148,8 @@
 				788C6545215CFDC700AF46A6 /* UITextView+ToolBarItemHelper.swift */,
 				788C6546215CFDC700AF46A6 /* UIFont+SymbolicTraits.swift */,
 				788C6547215CFDC700AF46A6 /* NSAttributedString+Helper.swift */,
+				A866BE4A24A9D062009E4012 /* UITextView+LinkPresentationHelper.swift */,
+				A866BE4E24A9EC78009E4012 /* String+Helper.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -166,6 +174,7 @@
 				78D616D9216B6FDA00440E71 /* ImageInputHandler */,
 				788C655D215CFE0B00AF46A6 /* ImagePickerManager.swift */,
 				78D616DA216B73D500440E71 /* LinkInputAlert.swift */,
+				A866BE5024AA5790009E4012 /* MetadataStorage.swift */,
 			);
 			path = SHRichTextEditor;
 			sourceTree = "<group>";
@@ -329,7 +338,7 @@
 				TargetAttributes = {
 					78B830311E5B0A32005B9057 = {
 						CreatedOnToolsVersion = 8.2.1;
-						DevelopmentTeam = HP3Q6K3LF3;
+						DevelopmentTeam = AMM55DP523;
 						LastSwiftMigration = 1130;
 						ProvisioningStyle = Automatic;
 					};
@@ -407,6 +416,7 @@
 				788C6555215CFDC700AF46A6 /* UIFont+SymbolicTraits.swift in Sources */,
 				788C654E215CFDC700AF46A6 /* RichTextEditor.swift in Sources */,
 				788C6551215CFDC700AF46A6 /* UITextView+Helpers.swift in Sources */,
+				A866BE4F24A9EC78009E4012 /* String+Helper.swift in Sources */,
 				788C6558215CFDC700AF46A6 /* ToolBarSpacer.swift in Sources */,
 				788C6556215CFDC700AF46A6 /* NSAttributedString+Helper.swift in Sources */,
 				788C6553215CFDC700AF46A6 /* UITextView+TapHandler.swift in Sources */,
@@ -416,6 +426,7 @@
 				788C6550215CFDC700AF46A6 /* UITextView+IndentationHelper.swift in Sources */,
 				788C654F215CFDC700AF46A6 /* UITextView+LinkHelper.swift in Sources */,
 				788C6566215CFE0B00AF46A6 /* UIViewController+Helper.swift in Sources */,
+				A866BE4B24A9D063009E4012 /* UITextView+LinkPresentationHelper.swift in Sources */,
 				788C656A215CFE0B00AF46A6 /* CameraInputView.swift in Sources */,
 				788C6557215CFDC700AF46A6 /* ToolBarItem.swift in Sources */,
 				788C6552215CFDC700AF46A6 /* UITextView+ImageHelper.swift in Sources */,
@@ -425,6 +436,7 @@
 				78D616DB216B73D500440E71 /* LinkInputAlert.swift in Sources */,
 				78D616D8216B6F6E00440E71 /* TextViewImageInputHandler.swift in Sources */,
 				788C6565215CFE0B00AF46A6 /* SHRichTextEditor.swift in Sources */,
+				A866BE5124AA5790009E4012 /* MetadataStorage.swift in Sources */,
 				788C6559215CFDC700AF46A6 /* ToolBarButtonExtensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -598,7 +610,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = HP3Q6K3LF3;
+				DEVELOPMENT_TEAM = AMM55DP523;
 				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = NO;
 				INFOPLIST_FILE = SHRichTextEditorTools/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -613,7 +625,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = HP3Q6K3LF3;
+				DEVELOPMENT_TEAM = AMM55DP523;
 				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = NO;
 				INFOPLIST_FILE = SHRichTextEditorTools/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/SHRichTextEditorTools/Base.lproj/Main.storyboard
+++ b/SHRichTextEditorTools/Base.lproj/Main.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -22,7 +20,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="xN6-yK-Acp">
-                                <rect key="frame" x="36" y="120" width="303" height="300"/>
+                                <rect key="frame" x="36" y="100" width="303" height="300"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="300" id="9s4-qn-Ymo"/>
@@ -32,7 +30,7 @@
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="xN6-yK-Acp" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="100" id="TI6-mw-YJ0"/>
                             <constraint firstAttribute="trailingMargin" secondItem="xN6-yK-Acp" secondAttribute="trailing" constant="20" id="e5Z-m1-Xs0"/>
@@ -45,6 +43,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="134" y="134"/>
         </scene>
     </scenes>
 </document>

--- a/SHRichTextEditorTools/Source/Core/Extensions/String+Helper.swift
+++ b/SHRichTextEditorTools/Source/Core/Extensions/String+Helper.swift
@@ -2,7 +2,7 @@
 //  String+Helper.swift
 //  SHRichTextEditorTools
 //
-//  Created by D2k on 29/06/20.
+//  Created by Ajay Bhanushali on 29/06/20.
 //  Copyright © 2020 hsusmita. All rights reserved.
 //
 
@@ -10,7 +10,7 @@ import Foundation
 
 extension String {
     var isValidURL: Bool {
-        let detector = try! NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+        guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else { return false }
         if let match = detector.firstMatch(in: self, options: [], range: NSRange(location: 0, length: self.utf16.count)) {
             return match.range.length == self.utf16.count
         } else {

--- a/SHRichTextEditorTools/Source/Core/Extensions/String+Helper.swift
+++ b/SHRichTextEditorTools/Source/Core/Extensions/String+Helper.swift
@@ -1,0 +1,20 @@
+//
+//  String+Helper.swift
+//  SHRichTextEditorTools
+//
+//  Created by D2k on 29/06/20.
+//  Copyright © 2020 hsusmita. All rights reserved.
+//
+
+import Foundation
+
+extension String {
+    var isValidURL: Bool {
+        let detector = try! NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+        if let match = detector.firstMatch(in: self, options: [], range: NSRange(location: 0, length: self.utf16.count)) {
+            return match.range.length == self.utf16.count
+        } else {
+            return false
+        }
+    }
+}

--- a/SHRichTextEditorTools/Source/Core/Extensions/UITextView+Helpers.swift
+++ b/SHRichTextEditorTools/Source/Core/Extensions/UITextView+Helpers.swift
@@ -71,10 +71,11 @@ public extension UITextView {
 	}
     
     var currentWord: String? {
-        let regex = try! NSRegularExpression(pattern: "\\S+$")
+        guard let regex = try? NSRegularExpression(pattern: "\\S+$") else { return nil }
         let textRange = NSRange(location: 0, length: selectedRange.location)
         if let range = regex.firstMatch(in: text, range: textRange)?.range {
-            return String(text[Range(range, in: text)!])
+            guard let finalRange = Range(range, in: text) else { return nil }
+            return String(text[finalRange])
         }
         return nil
     }

--- a/SHRichTextEditorTools/Source/Core/Extensions/UITextView+Helpers.swift
+++ b/SHRichTextEditorTools/Source/Core/Extensions/UITextView+Helpers.swift
@@ -69,4 +69,13 @@ public extension UITextView {
 		let characterIndex = layoutManager.characterIndex(for: finalLocation, in: textContainer, fractionOfDistanceBetweenInsertionPoints: nil)
 		return characterIndex
 	}
+    
+    var currentWord: String? {
+        let regex = try! NSRegularExpression(pattern: "\\S+$")
+        let textRange = NSRange(location: 0, length: selectedRange.location)
+        if let range = regex.firstMatch(in: text, range: textRange)?.range {
+            return String(text[Range(range, in: text)!])
+        }
+        return nil
+    }
 }

--- a/SHRichTextEditorTools/Source/Core/Extensions/UITextView+LinkPresentationHelper.swift
+++ b/SHRichTextEditorTools/Source/Core/Extensions/UITextView+LinkPresentationHelper.swift
@@ -2,7 +2,7 @@
 //  UITextView+LinkPresentationHelper.swift
 //  SHRichTextEditorTools
 //
-//  Created by D2k on 29/06/20.
+//  Created by Ajay Bhanushali on 29/06/20.
 //  Copyright © 2020 hsusmita. All rights reserved.
 //
 
@@ -12,8 +12,8 @@ import LinkPresentation
 extension UITextView {
 
     @available(iOS 13.0, *)
-    func inserLPView(for urlString: String) {
-        getPreviewImage(for: urlString) { [weak self] linkView in
+    func insertLPView(for urlString: String) {
+        getLPLinkView(for: urlString) { [weak self] linkView in
             guard let self = self else { return }
             
             self.superview?.insertSubview(linkView, belowSubview: self)
@@ -41,7 +41,7 @@ extension UITextView {
                 currentAtStr.append(attachmentAtStr)
             }
             
-            let regex = try! NSRegularExpression(pattern: "\\S+$")
+            guard let regex = try? NSRegularExpression(pattern: "\\S+$") else { return }
             let textRange = NSRange(location: 0, length: self.selectedRange.location)
             
             if let range = regex.firstMatch(in: self.text, range: textRange)?.range {
@@ -53,8 +53,7 @@ extension UITextView {
     }
     
     @available(iOS 13.0, *)
-    func getPreviewImage(for urlString: String, callBack: @escaping (LPLinkView)->Void) {
-        let metadataStorage = MetadataStorage()
+    func getLPLinkView(for urlString: String, callBack: @escaping (LPLinkView)->Void) {
         let metadataProvider = LPMetadataProvider()
         
         let linkView = LPLinkView(metadata: LPLinkMetadata())
@@ -62,7 +61,7 @@ extension UITextView {
                                      height: self.frame.size.height)
         
         if let url = URL(string: urlString) {
-            if let metadata = metadataStorage.metadata(for: url) {
+            if let metadata = UserDefaults.standard.metadata(for: url) {
                 linkView.metadata = metadata
                 callBack(linkView)
                 return
@@ -73,7 +72,7 @@ extension UITextView {
                 }
                 else if let metadata = metadata {
                     DispatchQueue.main.async {
-                        metadataStorage.store(metadata)
+                        UserDefaults.standard.store(metadata)
                         linkView.metadata = metadata
                         callBack(linkView)
                         return

--- a/SHRichTextEditorTools/Source/Core/Extensions/UITextView+LinkPresentationHelper.swift
+++ b/SHRichTextEditorTools/Source/Core/Extensions/UITextView+LinkPresentationHelper.swift
@@ -1,0 +1,87 @@
+//
+//  UITextView+LinkPresentationHelper.swift
+//  SHRichTextEditorTools
+//
+//  Created by D2k on 29/06/20.
+//  Copyright © 2020 hsusmita. All rights reserved.
+//
+
+import UIKit.UITextView
+import LinkPresentation
+
+extension UITextView {
+
+    @available(iOS 13.0, *)
+    func inserLPView(for urlString: String) {
+        getPreviewImage(for: urlString) { [weak self] linkView in
+            guard let self = self else { return }
+            
+            self.superview?.insertSubview(linkView, belowSubview: self)
+            linkView.sizeToFit()
+
+            let renderer = UIGraphicsImageRenderer(size: linkView.frame.size)
+            let image = renderer.image {
+                linkView.layer.render(in: $0.cgContext)
+            }
+
+            linkView.removeFromSuperview()
+            
+            let attachment = NSTextAttachment()
+            attachment.image = image
+            attachment.bounds = CGRect(origin: .zero, size: image.size)
+            
+            let currentAtStr = NSMutableAttributedString(attributedString: self.attributedText)
+            let attachmentAtStr = NSAttributedString(attachment: attachment)
+            
+            if let selectedRange = self.selectedTextRange {
+                let cursorIndex = self.offset(from: self.beginningOfDocument, to: selectedRange.start)
+                currentAtStr.insert(attachmentAtStr, at: cursorIndex)
+                currentAtStr.addAttributes(self.typingAttributes, range: NSRange(location: cursorIndex, length: 1))
+            } else {
+                currentAtStr.append(attachmentAtStr)
+            }
+            
+            let regex = try! NSRegularExpression(pattern: "\\S+$")
+            let textRange = NSRange(location: 0, length: self.selectedRange.location)
+            
+            if let range = regex.firstMatch(in: self.text, range: textRange)?.range {
+                currentAtStr.replaceCharacters(in: range, with: "")
+            }
+            
+            self.attributedText = currentAtStr
+        }
+    }
+    
+    @available(iOS 13.0, *)
+    func getPreviewImage(for urlString: String, callBack: @escaping (LPLinkView)->Void) {
+        let metadataStorage = MetadataStorage()
+        let metadataProvider = LPMetadataProvider()
+        
+        let linkView = LPLinkView(metadata: LPLinkMetadata())
+        linkView.frame.size = CGSize(width: self.frame.size.width-self.textContainer.lineFragmentPadding*2,
+                                     height: self.frame.size.height)
+        
+        if let url = URL(string: urlString) {
+            if let metadata = metadataStorage.metadata(for: url) {
+                linkView.metadata = metadata
+                callBack(linkView)
+                return
+            }
+            metadataProvider.startFetchingMetadata(for: url) { (metadata, error) in
+                if let error = error {
+                    print(error)
+                }
+                else if let metadata = metadata {
+                    DispatchQueue.main.async {
+                        metadataStorage.store(metadata)
+                        linkView.metadata = metadata
+                        callBack(linkView)
+                        return
+                    }
+                }
+            }
+        }
+    }
+}
+
+

--- a/SHRichTextEditorTools/Source/Core/Extensions/UITextView+TapHandler.swift
+++ b/SHRichTextEditorTools/Source/Core/Extensions/UITextView+TapHandler.swift
@@ -63,6 +63,10 @@ public extension UITextView {
 		}
 
 	}
+    
+    func updateTappedIndex(to index: Int) {
+        self.currentTappedIndex = index
+    }
 }
 
 extension UITextView: UIGestureRecognizerDelegate {

--- a/SHRichTextEditorTools/Source/Core/Extensions/UserDefaults+Helper.swift
+++ b/SHRichTextEditorTools/Source/Core/Extensions/UserDefaults+Helper.swift
@@ -1,25 +1,26 @@
 //
-//  MetadataStorage.swift
+//  UserDefaults+Helper.swift
 //  SHRichTextEditorTools
 //
-//  Created by D2k on 29/06/20.
+//  Created by Ajay Bhanushali on 10/07/20.
 //  Copyright © 2020 hsusmita. All rights reserved.
 //
 
 import LinkPresentation
 
 @available(iOS 13.0, *)
-struct MetadataStorage {
-    private let storage = UserDefaults.standard
-    
+extension UserDefaults {
     func store(_ metadata: LPLinkMetadata) {
+        let storage = UserDefaults.standard
         do {
             let data = try NSKeyedArchiver.archivedData(withRootObject: metadata, requiringSecureCoding: true)
             var metadatas = storage.dictionary(forKey: "Metadata") as? [String: Data] ?? [String: Data]()
             while metadatas.count > 10 {
-                metadatas.removeValue(forKey: metadatas.randomElement()!.key)
+                guard let key = metadatas.randomElement()?.key else { return }
+                metadatas.removeValue(forKey: key)
             }
-            metadatas[metadata.originalURL!.absoluteString] = data
+            guard let absString = metadata.originalURL?.absoluteString else { return }
+            metadatas[absString] = data
             storage.set(metadatas, forKey: "Metadata")
         }
         catch {
@@ -28,6 +29,7 @@ struct MetadataStorage {
     }
     
     func metadata(for url: URL) -> LPLinkMetadata? {
+        let storage = UserDefaults.standard
         guard let metadatas = storage.dictionary(forKey: "Metadata") as? [String: Data] else { return nil }
         guard let data = metadatas[url.absoluteString] else { return nil }
         do {

--- a/SHRichTextEditorTools/Source/SHRichTextEditor/ImageInputHandler/ImageBorderView/ImageBorderView.swift
+++ b/SHRichTextEditorTools/Source/SHRichTextEditor/ImageInputHandler/ImageBorderView/ImageBorderView.swift
@@ -29,7 +29,7 @@ class ImageBorderView: UIView {
 	}
 
 	@IBAction private func didTapDeleteButton(_ sender: Any) {
-		self.removeFromSuperview()
+        self.removeFromSuperview()
 		self.actionOnDeleteTap?()
 	}
 }

--- a/SHRichTextEditorTools/Source/SHRichTextEditor/ImageInputHandler/TextViewImageInputHandler.swift
+++ b/SHRichTextEditorTools/Source/SHRichTextEditor/ImageInputHandler/TextViewImageInputHandler.swift
@@ -20,6 +20,7 @@ public class TextViewImageInputHandler: ImageInputHandler {
             guard let currentIndex = textView.currentTappedIndex else {
                 return
             }
+            
             let mutableAttributedString = NSMutableAttributedString(attributedString: textView.attributedText)
             mutableAttributedString.replaceCharacters(in: NSRange(location: currentIndex, length: 1), with: "")
             textView.attributedText = mutableAttributedString

--- a/SHRichTextEditorTools/Source/SHRichTextEditor/MetadataStorage.swift
+++ b/SHRichTextEditorTools/Source/SHRichTextEditor/MetadataStorage.swift
@@ -1,0 +1,41 @@
+//
+//  MetadataStorage.swift
+//  SHRichTextEditorTools
+//
+//  Created by D2k on 29/06/20.
+//  Copyright © 2020 hsusmita. All rights reserved.
+//
+
+import LinkPresentation
+
+@available(iOS 13.0, *)
+struct MetadataStorage {
+    private let storage = UserDefaults.standard
+    
+    func store(_ metadata: LPLinkMetadata) {
+        do {
+            let data = try NSKeyedArchiver.archivedData(withRootObject: metadata, requiringSecureCoding: true)
+            var metadatas = storage.dictionary(forKey: "Metadata") as? [String: Data] ?? [String: Data]()
+            while metadatas.count > 10 {
+                metadatas.removeValue(forKey: metadatas.randomElement()!.key)
+            }
+            metadatas[metadata.originalURL!.absoluteString] = data
+            storage.set(metadatas, forKey: "Metadata")
+        }
+        catch {
+            print("Failed storing metadata with error \(error as NSError)")
+        }
+    }
+    
+    func metadata(for url: URL) -> LPLinkMetadata? {
+        guard let metadatas = storage.dictionary(forKey: "Metadata") as? [String: Data] else { return nil }
+        guard let data = metadatas[url.absoluteString] else { return nil }
+        do {
+            return try NSKeyedUnarchiver.unarchivedObject(ofClass: LPLinkMetadata.self, from: data)
+        }
+        catch {
+            print("Failed to unarchive metadata with error \(error as NSError)")
+            return nil
+        }
+    }
+}

--- a/SHRichTextEditorTools/Source/SHRichTextEditor/SHRichTextEditor.swift
+++ b/SHRichTextEditorTools/Source/SHRichTextEditor/SHRichTextEditor.swift
@@ -195,19 +195,24 @@ open class SHRichTextEditor: NSObject, RichTextEditor {
     private func handleLinkPreview() {
         textViewDelegate.registerShouldChangeText { (textView, range, text) -> (Bool) in
             if text == "\n" {
+                guard let validCursorPosition = textView.currentCursorPosition, validCursorPosition > 0 else { return true }
                 if let urlString = textView.currentWord, urlString.isValidURL {
                     if #available(iOS 13.0, *) {
-                        textView.inserLPView(for: urlString)
+                        textView.insertLPView(for: urlString)
                     }
+                } else {
+                    textView.updateTappedIndex(to: validCursorPosition-1)
                 }
-            } else if text == "" && range.length > 0 && textView.currentCursorPosition != nil, textView.currentCursorPosition! > 0 {
-                if textView.attributedText.imagePresent(at: textView.currentCursorPosition!-1) {
+            } else if text == "" && range.length > 0 {
+                guard let validCursorPosition = textView.currentCursorPosition, validCursorPosition > 0 else { return true }
+                if textView.attributedText.imagePresent(at: validCursorPosition-1) {
                     if let selectionView = self.textViewImageInputHandler.imageSelectionView {
                         if textView.subviews.contains(selectionView) {
                             textView.clearImageSelection(selectionView: selectionView)
                             return true
                         } else {
-                            textView.selectImage(at: textView.currentCursorPosition!-1, selectionView: selectionView)
+                            textView.updateTappedIndex(to: validCursorPosition-1)
+                            textView.selectImage(at: validCursorPosition-1, selectionView: selectionView)
                             return false
                         }
                     }

--- a/SHRichTextEditorTools/Source/SHRichTextEditor/SHRichTextEditor.swift
+++ b/SHRichTextEditorTools/Source/SHRichTextEditor/SHRichTextEditor.swift
@@ -200,7 +200,7 @@ open class SHRichTextEditor: NSObject, RichTextEditor {
                         textView.inserLPView(for: urlString)
                     }
                 }
-            } else if text == "" && range.length > 0 {
+            } else if text == "" && range.length > 0 && textView.currentCursorPosition != nil, textView.currentCursorPosition! > 0 {
                 if textView.attributedText.imagePresent(at: textView.currentCursorPosition!-1) {
                     if let selectionView = self.textViewImageInputHandler.imageSelectionView {
                         if textView.subviews.contains(selectionView) {

--- a/SHRichTextEditorTools/ViewController.swift
+++ b/SHRichTextEditorTools/ViewController.swift
@@ -14,6 +14,8 @@ final class ViewController: UIViewController {
 	
 	override func viewDidLoad() {
 		super.viewDidLoad()
+        textView.text = ""
+        textView.becomeFirstResponder()
 		self.textEditor = SHRichTextEditor(textView: self.textView)
 		let wordCountToolBarItem = ToolBarButton.configureWordCountToolBarButton(
 			countTextColor: UIColor.blue,


### PR DESCRIPTION
Link Preview for iOS 13 is developed in the existing library. 
1. LinkPresentation + LPLinkView is used to show the preview
2. Existing delegates/features such as imagePresent, textViewInputHandler, selectImage, clearImageSelection is used to create expected UI/UX.